### PR TITLE
fix(d-form-textarea): add the 'value' prop

### DIFF
--- a/src/components/form-textarea/FormTextarea.vue
+++ b/src/components/form-textarea/FormTextarea.vue
@@ -1,6 +1,7 @@
 <template>
   <textarea
     ref="input"
+    v-model="localValue"
     :class="[
             plaintext ? 'form-control-plaintext' : 'form-control',
             plaintext ? 'w-100' : '',
@@ -19,7 +20,6 @@
     :wrap="wrap"
     :aria-required="required ? 'true' : null"
     :aria-invalid="computedAriaInvalid"
-    @input="handleInput"
   ></textarea>
 </template>
 
@@ -34,6 +34,13 @@ export default {
     };
   },
   props: {
+    /**
+     * The element value.
+     */
+    value: {
+      type: String,
+      default: ''
+    },
     /**
      * The element name.
      */
@@ -241,10 +248,5 @@ export default {
       }
     }
   },
-  methods: {
-    handleInput(e) {
-      this.localValue = e.target.value;
-    }
-  }
 };
 </script>


### PR DESCRIPTION
Passing a `value` prop to the `FormTextarea` didn't do anything for two reasons:

* the `value` prop wasn't declared, so it was always undefined

* the `localValue` prop wasn't passed to the underlying textarea component, so the textarea wasn't controlled (it did not show the current value).

Using a `v-model` on the textarea simplifies the code a bit by sending and updating `localValue` at the same time.

PS - I read the contributing guidelines after making a fix for this issue, that's why I didn't take time to discuss about it first. Of course, we can still discuss this, and feel free to discard the PR completely.