### PR TITLE
Update Link.vue

### DIFF
--- a/src/components/link/Link.vue
+++ b/src/components/link/Link.vue
@@ -11,7 +11,7 @@
             disabled ? 'disabled' : ''
         ]"
         :aria-disabled="computedAriaDisabled"
-        @click.native="handleClick">
+        @click="handleClick">
         <slot>Link</slot>
     </component>
 </template>


### PR DESCRIPTION
Remove .native modifier. Vue outputs this warning: The .native modifier for v-on is only valid on components but it was used on <a>